### PR TITLE
Add editable food detail screen

### DIFF
--- a/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
@@ -1,0 +1,26 @@
+import Foundation
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+@MainActor
+class FoodDetailViewModel: ObservableObject {
+    @Published var food: Food
+    init(food: Food) {
+        self.food = food
+    }
+
+    func updateFood() {
+        guard let id = food.id else { return }
+        let data: [String: Any] = [
+            "name": food.name,
+            "expireDate": Timestamp(date: food.expireDate),
+            "updatedAt": Timestamp(date: Date())
+        ]
+        Firestore.firestore().collection("foods").document(id).updateData(data)
+    }
+
+    func deleteFood() {
+        guard let id = food.id else { return }
+        Firestore.firestore().collection("foods").document(id).delete()
+    }
+}

--- a/Sources/FoodExpire/Views/FoodDetailView.swift
+++ b/Sources/FoodExpire/Views/FoodDetailView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct FoodDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel: FoodDetailViewModel
+    @State private var showDeleteAlert = false
+
+    init(food: Food) {
+        _viewModel = StateObject(wrappedValue: FoodDetailViewModel(food: food))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                AsyncImage(url: URL(string: viewModel.food.imageUrl)) { image in
+                    image.resizable().scaledToFit()
+                } placeholder: {
+                    Color.gray
+                }
+                .frame(height: 200)
+
+                TextField("食品名", text: $viewModel.food.name)
+                    .textFieldStyle(.roundedBorder)
+
+                DatePicker("賞味期限", selection: $viewModel.food.expireDate, displayedComponents: .date)
+                    .datePickerStyle(.compact)
+
+                Button("更新") {
+                    viewModel.updateFood()
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("消費済み（削除）", role: .destructive) {
+                    showDeleteAlert = true
+                }
+                .buttonStyle(.bordered)
+                .alert("削除してもよろしいですか？", isPresented: $showDeleteAlert) {
+                    Button("キャンセル", role: .cancel) {}
+                    Button("削除", role: .destructive) {
+                        viewModel.deleteFood()
+                        dismiss()
+                    }
+                } message: {
+                    Text("この食品を削除します")
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("食品詳細")
+    }
+}
+
+#Preview {
+    FoodDetailView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date()))
+}

--- a/Sources/FoodExpire/Views/FoodListView.swift
+++ b/Sources/FoodExpire/Views/FoodListView.swift
@@ -7,7 +7,11 @@ struct FoodListView: View {
     var body: some View {
         NavigationStack {
             List(viewModel.foods) { food in
-                FoodCardView(food: food)
+                NavigationLink {
+                    FoodDetailView(food: food)
+                } label: {
+                    FoodCardView(food: food)
+                }
             }
             .listStyle(.plain)
             .navigationTitle("食品一覧")


### PR DESCRIPTION
## Summary
- add `FoodDetailView` for viewing a food item and editing its data
- handle update/delete in new `FoodDetailViewModel`
- open detail screen from each food card in `FoodListView`

## Testing
- `swift build` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a2b29a9dc832792f2336335555abe