### PR TITLE
Implement local notification for food expiration

### DIFF
--- a/Sources/FoodExpire/ContentView.swift
+++ b/Sources/FoodExpire/ContentView.swift
@@ -1,9 +1,15 @@
 import SwiftUI
 
 struct ContentView: View {
+    @EnvironmentObject private var notificationManager: NotificationManager
+
     var body: some View {
         FoodListView()
-        FoodRegisterView()
+            .sheet(item: $notificationManager.selectedFood) { food in
+                NavigationStack {
+                    FoodDetailView(food: food)
+                }
+            }
     }
 }
 

--- a/Sources/FoodExpire/FoodExpireApp.swift
+++ b/Sources/FoodExpire/FoodExpireApp.swift
@@ -3,13 +3,20 @@ import FirebaseCore
 
 @main
 struct FoodExpireApp: App {
+    @StateObject private var notificationManager = NotificationManager.shared
+
     init() {
         FirebaseApp.configure()
+        notificationManager.requestAuthorization()
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(notificationManager)
+                .onAppear {
+                    notificationManager.reloadSchedule()
+                }
         }
     }
 }

--- a/Sources/FoodExpire/FoodRegisterView.swift
+++ b/Sources/FoodExpire/FoodRegisterView.swift
@@ -105,7 +105,9 @@ struct FoodRegisterView: View {
         if let image = selectedImage, let imageData = image.jpegData(compressionQuality: 0.8) {
             data["imageUrl"] = imageData.base64EncodedString()
         }
-        db.collection("foods").addDocument(data: data)
+        let ref = db.collection("foods").addDocument(data: data)
+        let newFood = Food(id: ref.documentID, name: foodName, imageUrl: data["imageUrl"] as? String ?? "", expireDate: date)
+        NotificationManager.shared.scheduleNotification(for: newFood)
         foodName = ""
         expireText = ""
         selectedImage = nil

--- a/Sources/FoodExpire/NotificationManager.swift
+++ b/Sources/FoodExpire/NotificationManager.swift
@@ -1,0 +1,72 @@
+import Foundation
+import UserNotifications
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+@MainActor
+final class NotificationManager: NSObject, ObservableObject, UNUserNotificationCenterDelegate {
+    static let shared = NotificationManager()
+
+    @Published var selectedFood: Food?
+
+    private override init() { super.init() }
+
+    func requestAuthorization() {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+            if granted {
+                self.reloadSchedule()
+            }
+        }
+    }
+
+    func reloadSchedule() {
+        let center = UNUserNotificationCenter.current()
+        center.removeAllPendingNotificationRequests()
+        Firestore.firestore().collection("foods").getDocuments { snapshot, _ in
+            guard let documents = snapshot?.documents else { return }
+            for doc in documents {
+                if let food = try? doc.data(as: Food.self) {
+                    self.scheduleNotification(for: food)
+                }
+            }
+        }
+    }
+
+    func scheduleNotification(for food: Food) {
+        guard let id = food.id else { return }
+        let content = UNMutableNotificationContent()
+        content.title = "賞味期限のお知らせ"
+        let days = Calendar.current.dateComponents([.day], from: Date(), to: food.expireDate).day ?? 0
+        content.body = "『\(food.name)』の賞味期限が(\(days)日後)に迫っています。"
+        content.sound = .default
+        content.userInfo = ["foodId": id]
+
+        let triggerDate = Calendar.current.date(byAdding: .day, value: -1, to: food.expireDate) ?? food.expireDate
+        var components = Calendar.current.dateComponents([.year, .month, .day], from: triggerDate)
+        components.hour = 9
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let request = UNNotificationRequest(identifier: "food_\(id)", content: content, trigger: trigger)
+        UNUserNotificationCenter.current().add(request)
+    }
+
+    func cancelNotification(for id: String) {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["food_\(id)"])
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        if let id = response.notification.request.content.userInfo["foodId"] as? String {
+            Firestore.firestore().collection("foods").document(id).getDocument { doc, _ in
+                if let doc = doc, let food = try? doc.data(as: Food.self) {
+                    self.selectedFood = food
+                }
+            }
+        }
+        completionHandler()
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound])
+    }
+}

--- a/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
@@ -16,11 +16,15 @@ class FoodDetailViewModel: ObservableObject {
             "expireDate": Timestamp(date: food.expireDate),
             "updatedAt": Timestamp(date: Date())
         ]
-        Firestore.firestore().collection("foods").document(id).updateData(data)
+        Firestore.firestore().collection("foods").document(id).updateData(data) { _ in
+            NotificationManager.shared.scheduleNotification(for: self.food)
+        }
     }
 
     func deleteFood() {
         guard let id = food.id else { return }
-        Firestore.firestore().collection("foods").document(id).delete()
+        Firestore.firestore().collection("foods").document(id).delete { _ in
+            NotificationManager.shared.cancelNotification(for: id)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `NotificationManager` to manage local notifications
- request notification permission and schedule in `FoodExpireApp`
- show detail view when launched from a notification
- schedule or cancel notifications when saving, updating or deleting foods

## Testing
- `swift build -c release` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a2c6a997883278314e33e82a9fd1b