### PR TITLE
Add AdMob banners

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,14 +15,16 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.15.0"),
-        .package(url: "https://github.com/google/GoogleMLKit.git", from: "3.2.0")
+        .package(url: "https://github.com/google/GoogleMLKit.git", from: "3.2.0"),
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", from: "10.13.0")
     ],
     targets: [
         .executableTarget(
             name: "FoodExpire",
             dependencies: [
                 .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
-                .product(name: "MLKitTextRecognition", package: "GoogleMLKit")
+                .product(name: "MLKitTextRecognition", package: "GoogleMLKit"),
+                .product(name: "GoogleMobileAds", package: "swift-package-manager-google-mobile-ads")
             ],
             resources: [
                 .process("Resources")

--- a/Sources/FoodExpire/ContentView.swift
+++ b/Sources/FoodExpire/ContentView.swift
@@ -15,5 +15,7 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .environmentObject(NotificationManager.shared)
+        .environmentObject(UserSettings())
 }
 

--- a/Sources/FoodExpire/FoodExpireApp.swift
+++ b/Sources/FoodExpire/FoodExpireApp.swift
@@ -1,19 +1,23 @@
 import SwiftUI
 import FirebaseCore
+import GoogleMobileAds
 
 @main
 struct FoodExpireApp: App {
     @StateObject private var notificationManager = NotificationManager.shared
+    @StateObject private var userSettings = UserSettings()
 
     init() {
         FirebaseApp.configure()
         notificationManager.requestAuthorization()
+        GADMobileAds.sharedInstance().start(completionHandler: nil)
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(notificationManager)
+                .environmentObject(userSettings)
                 .onAppear {
                     notificationManager.reloadSchedule()
                 }

--- a/Sources/FoodExpire/Resources/Info.plist
+++ b/Sources/FoodExpire/Resources/Info.plist
@@ -18,6 +18,8 @@
     <string>1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>GADApplicationIdentifier</key>
+    <string>ca-app-pub-3940256099942544~1458002511</string>
     <key>UILaunchScreen</key>
     <dict/>
     <key>UIMainStoryboardFile</key>

--- a/Sources/FoodExpire/UserSettings.swift
+++ b/Sources/FoodExpire/UserSettings.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+final class UserSettings: ObservableObject {
+    @Published var isPremium: Bool = false
+}

--- a/Sources/FoodExpire/Views/BannerAdView.swift
+++ b/Sources/FoodExpire/Views/BannerAdView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import GoogleMobileAds
+
+struct BannerAdView: UIViewRepresentable {
+    func makeUIView(context: Context) -> GADBannerView {
+        let size = GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(UIScreen.main.bounds.width)
+        let banner = GADBannerView(adSize: size)
+        banner.adUnitID = "ca-app-pub-3940256099942544/2934735716"
+        banner.rootViewController = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }?.rootViewController
+        banner.load(GADRequest())
+        return banner
+    }
+
+    func updateUIView(_ uiView: GADBannerView, context: Context) {}
+}
+
+#Preview {
+    BannerAdView()
+        .frame(height: 50)
+}

--- a/Sources/FoodExpire/Views/FoodDetailView.swift
+++ b/Sources/FoodExpire/Views/FoodDetailView.swift
@@ -4,6 +4,7 @@ struct FoodDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel: FoodDetailViewModel
     @State private var showDeleteAlert = false
+    @EnvironmentObject private var userSettings: UserSettings
 
     init(food: Food) {
         _viewModel = StateObject(wrappedValue: FoodDetailViewModel(food: food))
@@ -48,9 +49,16 @@ struct FoodDetailView: View {
             .padding()
         }
         .navigationTitle("食品詳細")
+        .safeAreaInset(edge: .bottom) {
+            if !userSettings.isPremium {
+                BannerAdView()
+                    .frame(height: 50)
+            }
+        }
     }
 }
 
 #Preview {
     FoodDetailView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date()))
+        .environmentObject(UserSettings())
 }

--- a/Sources/FoodExpire/Views/FoodListView.swift
+++ b/Sources/FoodExpire/Views/FoodListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct FoodListView: View {
     @StateObject private var viewModel = FoodListViewModel()
     @State private var showAdd = false
+    @EnvironmentObject private var userSettings: UserSettings
 
     var body: some View {
         NavigationStack {
@@ -26,11 +27,18 @@ struct FoodListView: View {
             .sheet(isPresented: $showAdd) {
                 AddFoodView()
             }
+            .safeAreaInset(edge: .bottom) {
+                if !userSettings.isPremium {
+                    BannerAdView()
+                        .frame(height: 50)
+                }
+            }
         }
     }
 }
 
 #Preview {
     FoodListView()
+        .environmentObject(UserSettings())
 }
 


### PR DESCRIPTION
## Summary
- integrate Google Mobile Ads SDK with SPM
- start AdMob at launch and expose premium flag via `UserSettings`
- add `BannerAdView` for showing adaptive banner ads
- display banner ads on food list and detail screens when not premium
- include AdMob app ID in Info.plist
- update previews

## Testing
- `swift build` *(fails: unable to clone dependencies and Info.plist not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_685a2d4cb710832791c94d508b20d3c0