### PR TITLE
Add non-consumable IAP for removing ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ expiration date which can be edited before saving to Firestore.
 - Save food items with expiration dates to Firestore.
 - List saved items sorted by expiration date.
 - Send notifications when items are about to expire.
+- Optional in-app purchase to remove banner ads.
 
 ## Setup
 1. Open `Package.swift` with Xcode 15 or later.

--- a/Sources/FoodExpire/InAppPurchaseManager.swift
+++ b/Sources/FoodExpire/InAppPurchaseManager.swift
@@ -1,0 +1,55 @@
+import Foundation
+import StoreKit
+
+enum StoreError: Error {
+    case failedVerification
+}
+
+struct InAppPurchaseManager {
+    static let removeAdsID = "remove_ads"
+
+    private static func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+        case .unverified:
+            throw StoreError.failedVerification
+        case .verified(let safe):
+            return safe
+        }
+    }
+
+    static func purchaseRemoveAds() async -> Bool {
+        do {
+            guard let product = try await Product.products(for: [removeAdsID]).first else {
+                return false
+            }
+            let result = try await product.purchase()
+            switch result {
+            case .success(let verification):
+                let transaction = try checkVerified(verification)
+                await transaction.finish()
+                UserDefaults.standard.set(true, forKey: "isPremium")
+                return true
+            default:
+                return false
+            }
+        } catch {
+            print("Purchase error: \(error)")
+            return false
+        }
+    }
+
+    static func restorePurchases() async -> Bool {
+        do {
+            for await result in Transaction.currentEntitlements {
+                if case .verified(let transaction) = result,
+                   transaction.productID == removeAdsID {
+                    UserDefaults.standard.set(true, forKey: "isPremium")
+                    return true
+                }
+            }
+        } catch {
+            print("Restore error: \(error)")
+        }
+        return false
+    }
+}

--- a/Sources/FoodExpire/UserSettings.swift
+++ b/Sources/FoodExpire/UserSettings.swift
@@ -1,5 +1,13 @@
 import Foundation
 
 final class UserSettings: ObservableObject {
-    @Published var isPremium: Bool = false
+    @Published var isPremium: Bool {
+        didSet {
+            UserDefaults.standard.set(isPremium, forKey: "isPremium")
+        }
+    }
+
+    init() {
+        self.isPremium = UserDefaults.standard.bool(forKey: "isPremium")
+    }
 }

--- a/Sources/FoodExpire/Views/FoodListView.swift
+++ b/Sources/FoodExpire/Views/FoodListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct FoodListView: View {
     @StateObject private var viewModel = FoodListViewModel()
     @State private var showAdd = false
+    @State private var showSettings = false
     @EnvironmentObject private var userSettings: UserSettings
 
     var body: some View {
@@ -17,6 +18,11 @@ struct FoodListView: View {
             .listStyle(.plain)
             .navigationTitle("食品一覧")
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: { showSettings = true }) {
+                        Image(systemName: "gear")
+                    }
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showAdd = true }) {
                         Image(systemName: "plus")
@@ -26,6 +32,10 @@ struct FoodListView: View {
             .onAppear { viewModel.fetchFoods() }
             .sheet(isPresented: $showAdd) {
                 AddFoodView()
+            }
+            .sheet(isPresented: $showSettings) {
+                NavigationStack { SettingsView() }
+                    .environmentObject(userSettings)
             }
             .safeAreaInset(edge: .bottom) {
                 if !userSettings.isPremium {

--- a/Sources/FoodExpire/Views/SettingsView.swift
+++ b/Sources/FoodExpire/Views/SettingsView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject private var userSettings: UserSettings
+    @State private var processing = false
+
+    var body: some View {
+        Form {
+            Section {
+                if userSettings.isPremium {
+                    HStack {
+                        Image(systemName: "checkmark.seal.fill")
+                        Text("広告非表示購入済み")
+                    }
+                } else {
+                    Button(action: { Task { await purchase() } }) {
+                        Text("広告を削除 (¥480)")
+                    }
+                }
+                Button("復元") {
+                    Task { await restore() }
+                }
+            }
+        }
+        .navigationTitle("設定")
+        .disabled(processing)
+    }
+
+    private func purchase() async {
+        processing = true
+        let success = await InAppPurchaseManager.purchaseRemoveAds()
+        processing = false
+        if success { userSettings.isPremium = true }
+    }
+
+    private func restore() async {
+        processing = true
+        let success = await InAppPurchaseManager.restorePurchases()
+        processing = false
+        if success { userSettings.isPremium = true }
+    }
+}
+
+#Preview {
+    NavigationStack { SettingsView() }
+        .environmentObject(UserSettings())
+}


### PR DESCRIPTION
## Summary
- add `InAppPurchaseManager` using StoreKit 2
- persist premium state in `UserSettings`
- add `SettingsView` with purchase and restore buttons
- show settings screen from food list
- document in-app purchase feature

## Testing
- `swift build` *(fails: CONNECT tunnel failed)*
- `swift test` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a2f7cdf548327ae6fb03827073993