### PR TITLE
Implement IAP sync and release prep

### DIFF
--- a/Sources/FoodExpire/DateFormatter+Expire.swift
+++ b/Sources/FoodExpire/DateFormatter+Expire.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension DateFormatter {
+    static let expireFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy/MM/dd"
+        return f
+    }()
+}

--- a/Sources/FoodExpire/FoodExpireApp.swift
+++ b/Sources/FoodExpire/FoodExpireApp.swift
@@ -11,6 +11,10 @@ struct FoodExpireApp: App {
         FirebaseApp.configure()
         notificationManager.requestAuthorization()
         GADMobileAds.sharedInstance().start(completionHandler: nil)
+        Task {
+            let premium = await InAppPurchaseManager.syncPremiumStatus()
+            await MainActor.run { userSettings.isPremium = premium }
+        }
     }
 
     var body: some Scene {

--- a/Sources/FoodExpire/FoodRegisterView.swift
+++ b/Sources/FoodExpire/FoodRegisterView.swift
@@ -9,6 +9,9 @@ struct FoodRegisterView: View {
     @State private var selectedImage: UIImage?
     @State private var foodName: String = ""
     @State private var expireText: String = ""
+    @State private var showNameAlert = false
+    @State private var showDateAlert = false
+    @State private var showSavedAlert = false
 
     var body: some View {
         NavigationView {
@@ -51,6 +54,9 @@ struct FoodRegisterView: View {
                     processImage(image)
                 }
             }
+            .alert("食品名を入力してください", isPresented: $showNameAlert) {}
+            .alert("賞味期限が過去の日付です", isPresented: $showDateAlert) {}
+            .alert("保存しました", isPresented: $showSavedAlert) {}
         }
     }
 
@@ -94,7 +100,18 @@ struct FoodRegisterView: View {
     }
 
     private func saveFood() {
-        guard let date = dateFromString(expireText) else { return }
+        guard !foodName.trimmingCharacters(in: .whitespaces).isEmpty else {
+            showNameAlert = true
+            return
+        }
+        guard let date = dateFromString(expireText) else {
+            showDateAlert = true
+            return
+        }
+        if Calendar.current.startOfDay(for: date) < Calendar.current.startOfDay(for: Date()) {
+            showDateAlert = true
+            return
+        }
         let db = Firestore.firestore()
         var data: [String: Any] = [
             "name": foodName,
@@ -111,12 +128,11 @@ struct FoodRegisterView: View {
         foodName = ""
         expireText = ""
         selectedImage = nil
+        showSavedAlert = true
     }
 
     private func dateFromString(_ str: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy/MM/dd"
-        return formatter.date(from: str)
+        DateFormatter.expireFormatter.date(from: str)
     }
 }
 

--- a/Sources/FoodExpire/InAppPurchaseManager.swift
+++ b/Sources/FoodExpire/InAppPurchaseManager.swift
@@ -33,7 +33,6 @@ struct InAppPurchaseManager {
                 return false
             }
         } catch {
-            print("Purchase error: \(error)")
             return false
         }
     }
@@ -48,8 +47,24 @@ struct InAppPurchaseManager {
                 }
             }
         } catch {
-            print("Restore error: \(error)")
+            return false
         }
+        return false
+    }
+
+    static func syncPremiumStatus() async -> Bool {
+        do {
+            for await result in Transaction.currentEntitlements {
+                if case .verified(let transaction) = result,
+                   transaction.productID == removeAdsID {
+                    UserDefaults.standard.set(true, forKey: "isPremium")
+                    return true
+                }
+            }
+        } catch {
+            return UserDefaults.standard.bool(forKey: "isPremium")
+        }
+        UserDefaults.standard.set(false, forKey: "isPremium")
         return false
     }
 }

--- a/Sources/FoodExpire/NotificationManager.swift
+++ b/Sources/FoodExpire/NotificationManager.swift
@@ -8,10 +8,24 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
     static let shared = NotificationManager()
 
     @Published var selectedFood: Food?
+    @Published var notificationsEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(notificationsEnabled, forKey: "notificationsEnabled")
+            if notificationsEnabled {
+                requestAuthorization()
+            } else {
+                UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+            }
+        }
+    }
 
-    private override init() { super.init() }
+    private override init() {
+        self.notificationsEnabled = UserDefaults.standard.object(forKey: "notificationsEnabled") as? Bool ?? true
+        super.init()
+    }
 
     func requestAuthorization() {
+        guard notificationsEnabled else { return }
         let center = UNUserNotificationCenter.current()
         center.delegate = self
         center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in

--- a/Sources/FoodExpire/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Sources/FoodExpire/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon.png",
+      "idiom" : "universal",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Sources/FoodExpire/Resources/Info.plist
+++ b/Sources/FoodExpire/Resources/Info.plist
@@ -20,12 +20,28 @@
     <string>1</string>
     <key>GADApplicationIdentifier</key>
     <string>ca-app-pub-3940256099942544~1458002511</string>
+    <key>CFBundleIcons</key>
+    <dict>
+        <key>CFBundlePrimaryIcon</key>
+        <dict>
+            <key>CFBundleIconName</key>
+            <string>AppIcon</string>
+        </dict>
+    </dict>
+    <key>NSCameraUsageDescription</key>
+    <string>カメラを使用して食品を撮影します</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>写真ライブラリから食品画像を選択します</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>広告表示のためにトラッキングを許可します</string>
+    <key>NSUserNotificationUsageDescription</key>
+    <string>賞味期限を通知します</string>
     <key>UILaunchScreen</key>
     <dict/>
     <key>UIMainStoryboardFile</key>
     <string></string>
     <key>UILaunchStoryboardName</key>
-    <string></string>
+    <string>LaunchScreen</string>
     <key>UIRequiredDeviceCapabilities</key>
     <array>
         <string>armv7</string>

--- a/Sources/FoodExpire/Resources/LaunchScreen.storyboard
+++ b/Sources/FoodExpire/Resources/LaunchScreen.storyboard
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES">
+    <scenes>
+        <scene sceneID="LaunchScene">
+            <objects>
+                <view key="view" contentMode="scaleToFill" id="launchView">
+                    <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                    <subviews>
+                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="FoodExpire" id="titleLabel">
+                            <rect key="frame" x="145" y="412" width="100" height="20"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <color key="textColor" systemColor="labelColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Sources/FoodExpire/Views/AddFoodView.swift
+++ b/Sources/FoodExpire/Views/AddFoodView.swift
@@ -2,8 +2,7 @@ import SwiftUI
 
 struct AddFoodView: View {
     var body: some View {
-        Text("食品登録画面")
-            .font(.title)
+        FoodRegisterView()
     }
 }
 

--- a/Sources/FoodExpire/Views/FoodCardView.swift
+++ b/Sources/FoodExpire/Views/FoodCardView.swift
@@ -45,9 +45,7 @@ struct FoodCardView: View {
     }
 
     private var dateString: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy/MM/dd"
-        return formatter.string(from: food.expireDate)
+        DateFormatter.expireFormatter.string(from: food.expireDate)
     }
 }
 

--- a/Sources/FoodExpire/Views/FoodDetailView.swift
+++ b/Sources/FoodExpire/Views/FoodDetailView.swift
@@ -4,6 +4,10 @@ struct FoodDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel: FoodDetailViewModel
     @State private var showDeleteAlert = false
+    @State private var showNameAlert = false
+    @State private var showDateAlert = false
+    @State private var showUpdatedAlert = false
+    @State private var showDeletedAlert = false
     @EnvironmentObject private var userSettings: UserSettings
 
     init(food: Food) {
@@ -27,8 +31,14 @@ struct FoodDetailView: View {
                     .datePickerStyle(.compact)
 
                 Button("更新") {
-                    viewModel.updateFood()
-                    dismiss()
+                    if viewModel.food.name.trimmingCharacters(in: .whitespaces).isEmpty {
+                        showNameAlert = true
+                    } else if Calendar.current.startOfDay(for: viewModel.food.expireDate) < Calendar.current.startOfDay(for: Date()) {
+                        showDateAlert = true
+                    } else {
+                        viewModel.updateFood()
+                        showUpdatedAlert = true
+                    }
                 }
                 .buttonStyle(.borderedProminent)
 
@@ -40,10 +50,13 @@ struct FoodDetailView: View {
                     Button("キャンセル", role: .cancel) {}
                     Button("削除", role: .destructive) {
                         viewModel.deleteFood()
-                        dismiss()
+                        showDeletedAlert = true
                     }
                 } message: {
                     Text("この食品を削除します")
+                }
+                .alert("削除しました", isPresented: $showDeletedAlert) {
+                    Button("OK") { dismiss() }
                 }
             }
             .padding()
@@ -55,6 +68,9 @@ struct FoodDetailView: View {
                     .frame(height: 50)
             }
         }
+        .alert("食品名を入力してください", isPresented: $showNameAlert) {}
+        .alert("賞味期限が過去の日付です", isPresented: $showDateAlert) {}
+        .alert("更新しました", isPresented: $showUpdatedAlert) { Button("OK") { dismiss() } }
     }
 }
 

--- a/Sources/FoodExpire/Views/FoodListView.swift
+++ b/Sources/FoodExpire/Views/FoodListView.swift
@@ -5,6 +5,7 @@ struct FoodListView: View {
     @State private var showAdd = false
     @State private var showSettings = false
     @EnvironmentObject private var userSettings: UserSettings
+    @EnvironmentObject private var notificationManager: NotificationManager
 
     var body: some View {
         NavigationStack {
@@ -36,6 +37,7 @@ struct FoodListView: View {
             .sheet(isPresented: $showSettings) {
                 NavigationStack { SettingsView() }
                     .environmentObject(userSettings)
+                    .environmentObject(notificationManager)
             }
             .safeAreaInset(edge: .bottom) {
                 if !userSettings.isPremium {
@@ -50,5 +52,6 @@ struct FoodListView: View {
 #Preview {
     FoodListView()
         .environmentObject(UserSettings())
+        .environmentObject(NotificationManager.shared)
 }
 

--- a/Sources/FoodExpire/Views/SettingsView.swift
+++ b/Sources/FoodExpire/Views/SettingsView.swift
@@ -2,10 +2,14 @@ import SwiftUI
 
 struct SettingsView: View {
     @EnvironmentObject private var userSettings: UserSettings
+    @EnvironmentObject private var notificationManager: NotificationManager
     @State private var processing = false
 
     var body: some View {
         Form {
+            Section("通知") {
+                Toggle("通知オン", isOn: $notificationManager.notificationsEnabled)
+            }
             Section {
                 if userSettings.isPremium {
                     HStack {
@@ -19,6 +23,15 @@ struct SettingsView: View {
                 }
                 Button("復元") {
                     Task { await restore() }
+                }
+            }
+            Section("アプリについて") {
+                Text("賞味期限を管理するシンプルなアプリです")
+                HStack {
+                    Text("バージョン")
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")
+                        .foregroundColor(.secondary)
                 }
             }
         }
@@ -44,4 +57,5 @@ struct SettingsView: View {
 #Preview {
     NavigationStack { SettingsView() }
         .environmentObject(UserSettings())
+        .environmentObject(NotificationManager.shared)
 }


### PR DESCRIPTION
## Summary
- check existing transactions and store premium state at launch
- validate registration and editing forms with alert messages
- add notification toggle and about section in Settings
- configure LaunchScreen and Info.plist permissions
- remove binary AppIcon asset

## Testing
- `swift build` *(fails: network restricted, Info.plist not allowed as resource)*

------
https://chatgpt.com/codex/tasks/task_e_685a305e3398832787a15166ed292122