### PR TITLE
Improve validation and error handling

### DIFF
--- a/Sources/FoodExpire/NotificationManager.swift
+++ b/Sources/FoodExpire/NotificationManager.swift
@@ -8,6 +8,7 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
     static let shared = NotificationManager()
 
     @Published var selectedFood: Food?
+    @Published var showSettingsAlert = false
     @Published var notificationsEnabled: Bool {
         didSet {
             UserDefaults.standard.set(notificationsEnabled, forKey: "notificationsEnabled")
@@ -31,6 +32,12 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
         center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
             if granted {
                 self.reloadSchedule()
+            }
+            if !granted {
+                DispatchQueue.main.async {
+                    self.notificationsEnabled = false
+                    self.showSettingsAlert = true
+                }
             }
         }
     }

--- a/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
@@ -9,22 +9,28 @@ class FoodDetailViewModel: ObservableObject {
         self.food = food
     }
 
-    func updateFood() {
-        guard let id = food.id else { return }
+    func updateFood(completion: @escaping (Error?) -> Void) {
+        guard let id = food.id else { completion(nil); return }
         let data: [String: Any] = [
             "name": food.name,
             "expireDate": Timestamp(date: food.expireDate),
             "updatedAt": Timestamp(date: Date())
         ]
-        Firestore.firestore().collection("foods").document(id).updateData(data) { _ in
-            NotificationManager.shared.scheduleNotification(for: self.food)
+        Firestore.firestore().collection("foods").document(id).updateData(data) { error in
+            if error == nil {
+                NotificationManager.shared.scheduleNotification(for: self.food)
+            }
+            completion(error)
         }
     }
 
-    func deleteFood() {
-        guard let id = food.id else { return }
-        Firestore.firestore().collection("foods").document(id).delete { _ in
-            NotificationManager.shared.cancelNotification(for: id)
+    func deleteFood(completion: @escaping (Error?) -> Void) {
+        guard let id = food.id else { completion(nil); return }
+        Firestore.firestore().collection("foods").document(id).delete { error in
+            if error == nil {
+                NotificationManager.shared.cancelNotification(for: id)
+            }
+            completion(error)
         }
     }
 }

--- a/Sources/FoodExpire/ViewModels/FoodListViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/FoodListViewModel.swift
@@ -5,12 +5,18 @@ import FirebaseFirestoreSwift
 @MainActor
 class FoodListViewModel: ObservableObject {
     @Published var foods: [Food] = []
+    @Published var fetchError: Bool = false
 
     func fetchFoods() {
         Firestore.firestore()
             .collection("foods")
             .order(by: "expireDate")
             .addSnapshotListener { [weak self] snapshot, error in
+                if let error = error {
+                    print("fetch error: \(error)")
+                    self?.fetchError = true
+                    return
+                }
                 guard let documents = snapshot?.documents else { return }
                 self?.foods = documents.compactMap { try? $0.data(as: Food.self) }
             }

--- a/Sources/FoodExpire/Views/FoodDetailView.swift
+++ b/Sources/FoodExpire/Views/FoodDetailView.swift
@@ -8,6 +8,8 @@ struct FoodDetailView: View {
     @State private var showDateAlert = false
     @State private var showUpdatedAlert = false
     @State private var showDeletedAlert = false
+    @State private var showUpdateErrorAlert = false
+    @State private var showDeleteErrorAlert = false
     @EnvironmentObject private var userSettings: UserSettings
 
     init(food: Food) {
@@ -36,8 +38,13 @@ struct FoodDetailView: View {
                     } else if Calendar.current.startOfDay(for: viewModel.food.expireDate) < Calendar.current.startOfDay(for: Date()) {
                         showDateAlert = true
                     } else {
-                        viewModel.updateFood()
-                        showUpdatedAlert = true
+                        viewModel.updateFood { error in
+                            if error != nil {
+                                showUpdateErrorAlert = true
+                            } else {
+                                showUpdatedAlert = true
+                            }
+                        }
                     }
                 }
                 .buttonStyle(.borderedProminent)
@@ -49,8 +56,13 @@ struct FoodDetailView: View {
                 .alert("削除してもよろしいですか？", isPresented: $showDeleteAlert) {
                     Button("キャンセル", role: .cancel) {}
                     Button("削除", role: .destructive) {
-                        viewModel.deleteFood()
-                        showDeletedAlert = true
+                        viewModel.deleteFood { error in
+                            if error != nil {
+                                showDeleteErrorAlert = true
+                            } else {
+                                showDeletedAlert = true
+                            }
+                        }
                     }
                 } message: {
                     Text("この食品を削除します")
@@ -71,6 +83,8 @@ struct FoodDetailView: View {
         .alert("食品名を入力してください", isPresented: $showNameAlert) {}
         .alert("賞味期限が過去の日付です", isPresented: $showDateAlert) {}
         .alert("更新しました", isPresented: $showUpdatedAlert) { Button("OK") { dismiss() } }
+        .alert("更新に失敗しました", isPresented: $showUpdateErrorAlert) {}
+        .alert("削除に失敗しました", isPresented: $showDeleteErrorAlert) {}
     }
 }
 

--- a/Sources/FoodExpire/Views/FoodListView.swift
+++ b/Sources/FoodExpire/Views/FoodListView.swift
@@ -31,6 +31,7 @@ struct FoodListView: View {
                 }
             }
             .onAppear { viewModel.fetchFoods() }
+            .alert("データの取得に失敗しました", isPresented: $viewModel.fetchError) {}
             .sheet(isPresented: $showAdd) {
                 AddFoodView()
             }


### PR DESCRIPTION
## Summary
- add permissions and OCR error fallbacks
- validate name length and Firestore errors when saving
- display Firestore update/delete errors
- handle notification permission denial
- surface IAP and data fetch errors

## Testing
- `swift build -c release` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a3d02e0908327a1c7f9340584711e