### PR TITLE
Add storage type selection and filtering

### DIFF
--- a/Sources/FoodExpire/FoodRegisterView.swift
+++ b/Sources/FoodExpire/FoodRegisterView.swift
@@ -12,6 +12,7 @@ struct FoodRegisterView: View {
     @State private var selectedImage: UIImage?
     @State private var foodName: String = ""
     @State private var expireText: String = ""
+    @State private var storageType: StorageType = .冷蔵
     @State private var showNameAlert = false
     @State private var showDateAlert = false
     @State private var showSavedAlert = false
@@ -47,6 +48,13 @@ struct FoodRegisterView: View {
                 TextField("賞味期限(YYYY/MM/DD)", text: $expireText)
                     .textFieldStyle(.roundedBorder)
                     .keyboardType(.numbersAndPunctuation)
+
+                Picker("保存場所", selection: $storageType) {
+                    ForEach(StorageType.allCases) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .pickerStyle(.segmented)
 
                 Button("保存") {
                     saveFood()
@@ -144,7 +152,8 @@ struct FoodRegisterView: View {
             "name": foodName,
             "expireDate": Timestamp(date: date),
             "createdAt": Timestamp(date: Date()),
-            "updatedAt": Timestamp(date: Date())
+            "updatedAt": Timestamp(date: Date()),
+            "storageType": storageType.rawValue
         ]
         if let image = selectedImage, let imageData = image.jpegData(compressionQuality: 0.8) {
             data["imageUrl"] = imageData.base64EncodedString()
@@ -154,11 +163,12 @@ struct FoodRegisterView: View {
                 showSaveErrorAlert = true
                 return
             }
-            let newFood = Food(id: ref.documentID, name: foodName, imageUrl: data["imageUrl"] as? String ?? "", expireDate: date)
+            let newFood = Food(id: ref.documentID, name: foodName, imageUrl: data["imageUrl"] as? String ?? "", expireDate: date, storageType: storageType)
             NotificationManager.shared.scheduleNotification(for: newFood)
             foodName = ""
             expireText = ""
             selectedImage = nil
+            storageType = .冷蔵
             showSavedAlert = true
         }
     }

--- a/Sources/FoodExpire/Models/Food.swift
+++ b/Sources/FoodExpire/Models/Food.swift
@@ -1,10 +1,16 @@
 import Foundation
 import FirebaseFirestoreSwift
 
+enum StorageType: String, CaseIterable, Codable, Identifiable {
+    case 冷蔵, 冷凍, 常温
+    var id: String { rawValue }
+}
+
 struct Food: Identifiable, Codable {
     @DocumentID var id: String?
     var name: String
     var imageUrl: String
     var expireDate: Date
+    var storageType: StorageType = .冷蔵
 }
 

--- a/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
@@ -14,7 +14,8 @@ class FoodDetailViewModel: ObservableObject {
         let data: [String: Any] = [
             "name": food.name,
             "expireDate": Timestamp(date: food.expireDate),
-            "updatedAt": Timestamp(date: Date())
+            "updatedAt": Timestamp(date: Date()),
+            "storageType": food.storageType.rawValue
         ]
         Firestore.firestore().collection("foods").document(id).updateData(data) { error in
             if error == nil {

--- a/Sources/FoodExpire/ViewModels/FoodListViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/FoodListViewModel.swift
@@ -6,6 +6,12 @@ import FirebaseFirestoreSwift
 class FoodListViewModel: ObservableObject {
     @Published var foods: [Food] = []
     @Published var fetchError: Bool = false
+    @Published var filter: StorageType? = nil
+
+    var filteredFoods: [Food] {
+        guard let filter = filter else { return foods }
+        return foods.filter { $0.storageType == filter }
+    }
 
     func fetchFoods() {
         Firestore.firestore()

--- a/Sources/FoodExpire/Views/FoodCardView.swift
+++ b/Sources/FoodExpire/Views/FoodCardView.swift
@@ -34,8 +34,16 @@ struct FoodCardView: View {
                     .font(.headline)
                 Text(dateString)
                     .font(.subheadline)
-                Text("残り\(remainingDays)日")
-                    .font(.caption)
+                HStack {
+                    Text("残り\(remainingDays)日")
+                        .font(.caption)
+                    Spacer()
+                    Text(food.storageType.rawValue)
+                        .font(.caption2)
+                        .padding(4)
+                        .background(Color.gray.opacity(0.2))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
             }
             Spacer()
         }
@@ -50,6 +58,6 @@ struct FoodCardView: View {
 }
 
 #Preview {
-    FoodCardView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date().addingTimeInterval(86400*5)))
+    FoodCardView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date().addingTimeInterval(86400*5), storageType: .冷蔵))
 }
 

--- a/Sources/FoodExpire/Views/FoodDetailView.swift
+++ b/Sources/FoodExpire/Views/FoodDetailView.swift
@@ -33,6 +33,13 @@ struct FoodDetailView: View {
                 DatePicker("賞味期限", selection: $viewModel.food.expireDate, displayedComponents: .date)
                     .datePickerStyle(.compact)
 
+                Picker("保存場所", selection: $viewModel.food.storageType) {
+                    ForEach(StorageType.allCases) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .pickerStyle(.segmented)
+
                 Button("更新") {
                     let trimmed = viewModel.food.name.trimmingCharacters(in: .whitespaces)
                     if trimmed.isEmpty {
@@ -94,6 +101,6 @@ struct FoodDetailView: View {
 }
 
 #Preview {
-    FoodDetailView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date()))
+    FoodDetailView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date(), storageType: .冷蔵))
         .environmentObject(UserSettings())
 }

--- a/Sources/FoodExpire/Views/FoodListView.swift
+++ b/Sources/FoodExpire/Views/FoodListView.swift
@@ -9,14 +9,25 @@ struct FoodListView: View {
 
     var body: some View {
         NavigationStack {
-            List(viewModel.foods) { food in
-                NavigationLink {
-                    FoodDetailView(food: food)
-                } label: {
-                    FoodCardView(food: food)
+            VStack {
+                Picker("保存場所", selection: $viewModel.filter) {
+                    Text("すべて").tag(StorageType?.none)
+                    ForEach(StorageType.allCases) { type in
+                        Text(type.rawValue).tag(Optional(type))
+                    }
                 }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
+                List(viewModel.filteredFoods) { food in
+                    NavigationLink {
+                        FoodDetailView(food: food)
+                    } label: {
+                        FoodCardView(food: food)
+                    }
+                }
+                .listStyle(.plain)
             }
-            .listStyle(.plain)
             .navigationTitle("食品一覧")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {


### PR DESCRIPTION
## Summary
- support different storage locations for food items
- let users choose storage type when registering food
- display storage type on cards
- allow editing storage type in detail view
- filter foods by storage location in list view

## Testing
- `swift build` *(fails: resource Info.plist is forbidden and network fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a60e563b483279088d0aa5b0989a4