### PR TITLE
Add note field to food items

### DIFF
--- a/Sources/FoodExpire/FoodRegisterView.swift
+++ b/Sources/FoodExpire/FoodRegisterView.swift
@@ -12,6 +12,7 @@ struct FoodRegisterView: View {
     @State private var selectedImage: UIImage?
     @State private var foodName: String = ""
     @State private var expireText: String = ""
+    @State private var note: String = ""
     @State private var showNameAlert = false
     @State private var showDateAlert = false
     @State private var showSavedAlert = false
@@ -47,6 +48,21 @@ struct FoodRegisterView: View {
                 TextField("賞味期限(YYYY/MM/DD)", text: $expireText)
                     .textFieldStyle(.roundedBorder)
                     .keyboardType(.numbersAndPunctuation)
+
+                ZStack(alignment: .topLeading) {
+                    if note.isEmpty {
+                        Text("開封済み・使い道・保管方法など自由に記入")
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 8)
+                    }
+                    TextEditor(text: $note)
+                        .frame(height: 80)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.secondary.opacity(0.3))
+                        }
+                }
 
                 Button("保存") {
                     saveFood()
@@ -144,7 +160,8 @@ struct FoodRegisterView: View {
             "name": foodName,
             "expireDate": Timestamp(date: date),
             "createdAt": Timestamp(date: Date()),
-            "updatedAt": Timestamp(date: Date())
+            "updatedAt": Timestamp(date: Date()),
+            "note": note
         ]
         if let image = selectedImage, let imageData = image.jpegData(compressionQuality: 0.8) {
             data["imageUrl"] = imageData.base64EncodedString()
@@ -154,11 +171,12 @@ struct FoodRegisterView: View {
                 showSaveErrorAlert = true
                 return
             }
-            let newFood = Food(id: ref.documentID, name: foodName, imageUrl: data["imageUrl"] as? String ?? "", expireDate: date)
+            let newFood = Food(id: ref.documentID, name: foodName, imageUrl: data["imageUrl"] as? String ?? "", expireDate: date, note: note.isEmpty ? nil : note)
             NotificationManager.shared.scheduleNotification(for: newFood)
             foodName = ""
             expireText = ""
             selectedImage = nil
+            note = ""
             showSavedAlert = true
         }
     }

--- a/Sources/FoodExpire/Models/Food.swift
+++ b/Sources/FoodExpire/Models/Food.swift
@@ -6,5 +6,6 @@ struct Food: Identifiable, Codable {
     var name: String
     var imageUrl: String
     var expireDate: Date
+    var note: String?
 }
 

--- a/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
@@ -14,7 +14,8 @@ class FoodDetailViewModel: ObservableObject {
         let data: [String: Any] = [
             "name": food.name,
             "expireDate": Timestamp(date: food.expireDate),
-            "updatedAt": Timestamp(date: Date())
+            "updatedAt": Timestamp(date: Date()),
+            "note": food.note ?? ""
         ]
         Firestore.firestore().collection("foods").document(id).updateData(data) { error in
             if error == nil {

--- a/Sources/FoodExpire/Views/FoodDetailView.swift
+++ b/Sources/FoodExpire/Views/FoodDetailView.swift
@@ -33,6 +33,24 @@ struct FoodDetailView: View {
                 DatePicker("賞味期限", selection: $viewModel.food.expireDate, displayedComponents: .date)
                     .datePickerStyle(.compact)
 
+                ZStack(alignment: .topLeading) {
+                    if (viewModel.food.note ?? "").isEmpty {
+                        Text("開封済み・使い道・保管方法など自由に記入")
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 8)
+                    }
+                    TextEditor(text: Binding(
+                        get: { viewModel.food.note ?? "" },
+                        set: { viewModel.food.note = $0 }
+                    ))
+                    .frame(height: 80)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.secondary.opacity(0.3))
+                    }
+                }
+
                 Button("更新") {
                     let trimmed = viewModel.food.name.trimmingCharacters(in: .whitespaces)
                     if trimmed.isEmpty {


### PR DESCRIPTION
## Summary
- include `note` field in `Food` model
- allow entering a memo when registering food
- save and clear the memo text when creating a new item
- show and edit the memo on the food detail screen
- update Firestore update logic to persist `note`

## Testing
- `swift build` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a68cdfdf083278b0867c9189c6e24