### PR TITLE
Add food re-register feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The app supports both Japanese and English localizations.
 - Save food items with expiration dates to Firestore.
 - List saved items sorted by expiration date.
 - Send notifications when items are about to expire.
+- Re-register previously saved foods from the detail screen.
 - Optional in-app purchase to remove banner ads.
 
 ## Setup

--- a/Sources/FoodExpire/FoodRegisterView.swift
+++ b/Sources/FoodExpire/FoodRegisterView.swift
@@ -7,12 +7,14 @@ import UIKit
 
 struct FoodRegisterView: View {
     private let maxNameLength = AppConstants.maxFoodNameLength
+    let originalFood: Food?
+
     @State private var showPhotoPicker = false
     @State private var showCameraPicker = false
     @State private var selectedImage: UIImage?
-    @State private var foodName: String = ""
-    @State private var expireText: String = ""
-    @State private var note: String = ""
+    @State private var foodName: String
+    @State private var expireText: String
+    @State private var note: String
     @State private var showNameAlert = false
     @State private var showDateAlert = false
     @State private var showSavedAlert = false
@@ -22,9 +24,37 @@ struct FoodRegisterView: View {
     @State private var showPhotoPermissionAlert = false
     @State private var showLengthAlert = false
 
+    init(originalFood: Food? = nil) {
+        self.originalFood = originalFood
+        if let food = originalFood {
+            _foodName = State(initialValue: food.name)
+            _note = State(initialValue: food.note ?? "")
+            _expireText = State(initialValue: "")
+            if let data = Data(base64Encoded: food.imageUrl),
+               let uiImage = UIImage(data: data) {
+                _selectedImage = State(initialValue: uiImage)
+            } else {
+                _selectedImage = State(initialValue: nil)
+            }
+        } else {
+            _foodName = State(initialValue: "")
+            _note = State(initialValue: "")
+            _expireText = State(initialValue: "")
+            _selectedImage = State(initialValue: nil)
+        }
+    }
+
     var body: some View {
         NavigationView {
             VStack(spacing: 16) {
+                if originalFood != nil {
+                    Text("再登録モード")
+                        .font(.caption)
+                        .padding(4)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.accentColor.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
                 HStack {
                     Button("写真撮影") {
                         checkCameraPermission()

--- a/Sources/FoodExpire/Views/AddFoodView.swift
+++ b/Sources/FoodExpire/Views/AddFoodView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 struct AddFoodView: View {
+    var originalFood: Food? = nil
     var body: some View {
-        FoodRegisterView()
+        FoodRegisterView(originalFood: originalFood)
     }
 }
 

--- a/Sources/FoodExpire/Views/FoodDetailView.swift
+++ b/Sources/FoodExpire/Views/FoodDetailView.swift
@@ -11,6 +11,7 @@ struct FoodDetailView: View {
     @State private var showDeletedAlert = false
     @State private var showUpdateErrorAlert = false
     @State private var showDeleteErrorAlert = false
+    @State private var showReRegister = false
     @EnvironmentObject private var userSettings: UserSettings
 
     init(food: Food) {
@@ -71,6 +72,11 @@ struct FoodDetailView: View {
                 }
                 .buttonStyle(.borderedProminent)
 
+                Button("再登録") {
+                    showReRegister = true
+                }
+                .buttonStyle(.bordered)
+
                 Button("消費済み（削除）", role: .destructive) {
                     showDeleteAlert = true
                 }
@@ -108,6 +114,9 @@ struct FoodDetailView: View {
         .alert("更新しました", isPresented: $showUpdatedAlert) { Button("OK") { dismiss() } }
         .alert("更新に失敗しました", isPresented: $showUpdateErrorAlert) {}
         .alert("削除に失敗しました", isPresented: $showDeleteErrorAlert) {}
+        .sheet(isPresented: $showReRegister) {
+            AddFoodView(originalFood: viewModel.food)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- allow AddFoodView to accept previously saved food data
- support re-registering food in FoodRegisterView and show '再登録モード' label
- add re-register button in FoodDetailView
- document new feature in README

## Testing
- `swift build` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_685a6d0dae44832799896c3ef22b279b