### PR TITLE
Add shopping list feature

### DIFF
--- a/Sources/FoodExpire/ContentView.swift
+++ b/Sources/FoodExpire/ContentView.swift
@@ -4,12 +4,17 @@ struct ContentView: View {
     @EnvironmentObject private var notificationManager: NotificationManager
 
     var body: some View {
-        FoodListView()
-            .sheet(item: $notificationManager.selectedFood) { food in
-                NavigationStack {
-                    FoodDetailView(food: food)
-                }
+        TabView {
+            FoodListView()
+                .tabItem { Label("食品", systemImage: "list.bullet") }
+            NavigationStack { ShoppingListView() }
+                .tabItem { Label("買い物", systemImage: "cart") }
+        }
+        .sheet(item: $notificationManager.selectedFood) { food in
+            NavigationStack {
+                FoodDetailView(food: food)
             }
+        }
     }
 }
 

--- a/Sources/FoodExpire/Models/ShoppingItem.swift
+++ b/Sources/FoodExpire/Models/ShoppingItem.swift
@@ -1,0 +1,11 @@
+import Foundation
+import FirebaseFirestoreSwift
+
+struct ShoppingItem: Identifiable, Codable {
+    @DocumentID var id: String?
+    var name: String
+    var createdAt: Date
+    var note: String?
+    var storageType: String?
+    var isChecked: Bool
+}

--- a/Sources/FoodExpire/ViewModels/ShoppingListViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/ShoppingListViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+@MainActor
+class ShoppingListViewModel: ObservableObject {
+    @Published var items: [ShoppingItem] = []
+    @Published var fetchError = false
+
+    func fetchItems() {
+        Firestore.firestore()
+            .collection("shoppingList")
+            .order(by: "createdAt", descending: true)
+            .addSnapshotListener { [weak self] snapshot, error in
+                if error != nil {
+                    self?.fetchError = true
+                    return
+                }
+                guard let documents = snapshot?.documents else { return }
+                self?.items = documents.compactMap { try? $0.data(as: ShoppingItem.self) }
+            }
+    }
+
+    func toggleChecked(_ item: ShoppingItem) {
+        guard let id = item.id else { return }
+        Firestore.firestore().collection("shoppingList").document(id)
+            .updateData(["isChecked": !item.isChecked])
+    }
+
+    func deleteItem(_ item: ShoppingItem) {
+        guard let id = item.id else { return }
+        Firestore.firestore().collection("shoppingList").document(id).delete()
+    }
+}

--- a/Sources/FoodExpire/Views/FoodDetailView.swift
+++ b/Sources/FoodExpire/Views/FoodDetailView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import FirebaseFirestore
 
 struct FoodDetailView: View {
     @Environment(\.dismiss) private var dismiss
@@ -12,6 +13,8 @@ struct FoodDetailView: View {
     @State private var showUpdateErrorAlert = false
     @State private var showDeleteErrorAlert = false
     @State private var showReRegister = false
+    @State private var showAddedAlert = false
+    @State private var showAddErrorAlert = false
     @EnvironmentObject private var userSettings: UserSettings
 
     init(food: Food) {
@@ -77,6 +80,11 @@ struct FoodDetailView: View {
                 }
                 .buttonStyle(.bordered)
 
+                Button("買い物リストに追加") {
+                    addToShoppingList()
+                }
+                .buttonStyle(.bordered)
+
                 Button("消費済み（削除）", role: .destructive) {
                     showDeleteAlert = true
                 }
@@ -114,8 +122,27 @@ struct FoodDetailView: View {
         .alert("更新しました", isPresented: $showUpdatedAlert) { Button("OK") { dismiss() } }
         .alert("更新に失敗しました", isPresented: $showUpdateErrorAlert) {}
         .alert("削除に失敗しました", isPresented: $showDeleteErrorAlert) {}
+        .alert("追加しました", isPresented: $showAddedAlert) {}
+        .alert("追加に失敗しました", isPresented: $showAddErrorAlert) {}
         .sheet(isPresented: $showReRegister) {
             AddFoodView(originalFood: viewModel.food)
+        }
+    }
+
+    private func addToShoppingList() {
+        let data: [String: Any] = [
+            "name": viewModel.food.name,
+            "createdAt": Timestamp(date: Date()),
+            "note": viewModel.food.note ?? "",
+            "storageType": "",
+            "isChecked": false
+        ]
+        Firestore.firestore().collection("shoppingList").addDocument(data: data) { error in
+            if error != nil {
+                showAddErrorAlert = true
+            } else {
+                showAddedAlert = true
+            }
         }
     }
 }

--- a/Sources/FoodExpire/Views/SettingsView.swift
+++ b/Sources/FoodExpire/Views/SettingsView.swift
@@ -14,6 +14,11 @@ struct SettingsView: View {
                 Toggle("通知オン", isOn: $notificationManager.notificationsEnabled)
             }
             Section {
+                NavigationLink("買い物リスト") {
+                    ShoppingListView()
+                }
+            }
+            Section {
                 if userSettings.isPremium {
                     HStack {
                         Image(systemName: "checkmark.seal.fill")

--- a/Sources/FoodExpire/Views/ShoppingListView.swift
+++ b/Sources/FoodExpire/Views/ShoppingListView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct ShoppingListView: View {
+    @StateObject private var viewModel = ShoppingListViewModel()
+
+    private var uncheckedItems: [ShoppingItem] {
+        viewModel.items.filter { !$0.isChecked }
+    }
+
+    private var checkedItems: [ShoppingItem] {
+        viewModel.items.filter { $0.isChecked }
+    }
+
+    var body: some View {
+        List {
+            ForEach(uncheckedItems) { item in
+                row(for: item)
+            }
+            if !checkedItems.isEmpty {
+                Section("購入済み") {
+                    ForEach(checkedItems) { item in
+                        row(for: item)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle("買い物リスト")
+        .onAppear { viewModel.fetchItems() }
+        .alert("データの取得に失敗しました", isPresented: $viewModel.fetchError) {}
+    }
+
+    @ViewBuilder
+    private func row(for item: ShoppingItem) -> some View {
+        HStack {
+            Button(action: { viewModel.toggleChecked(item) }) {
+                Image(systemName: item.isChecked ? "checkmark.square" : "square")
+            }
+            .buttonStyle(.plain)
+            VStack(alignment: .leading) {
+                Text(item.name)
+                Text(DateFormatter.expireFormatter.string(from: item.createdAt))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .swipeActions {
+            Button(role: .destructive) {
+                viewModel.deleteItem(item)
+            } label: {
+                Label("削除", systemImage: "trash")
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack { ShoppingListView() }
+}


### PR DESCRIPTION
## Summary
- add `ShoppingItem` model for items stored in Firestore
- implement `ShoppingListViewModel` and `ShoppingListView`
- integrate shopping list through new tab and settings link
- allow foods to be copied to shopping list from detail view

## Testing
- `swift build --product FoodExpire` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a6e09afd48327a9c8c72451b947de