### PR TITLE
Add storage type support

### DIFF
--- a/Sources/FoodExpire/FoodRegisterView.swift
+++ b/Sources/FoodExpire/FoodRegisterView.swift
@@ -15,6 +15,7 @@ struct FoodRegisterView: View {
     @State private var foodName: String
     @State private var expireText: String
     @State private var note: String
+    @State private var storageType: StorageType
     @State private var showNameAlert = false
     @State private var showDateAlert = false
     @State private var showSavedAlert = false
@@ -30,6 +31,7 @@ struct FoodRegisterView: View {
             _foodName = State(initialValue: food.name)
             _note = State(initialValue: food.note ?? "")
             _expireText = State(initialValue: "")
+            _storageType = State(initialValue: food.storageType)
             if let data = Data(base64Encoded: food.imageUrl),
                let uiImage = UIImage(data: data) {
                 _selectedImage = State(initialValue: uiImage)
@@ -41,6 +43,7 @@ struct FoodRegisterView: View {
             _note = State(initialValue: "")
             _expireText = State(initialValue: "")
             _selectedImage = State(initialValue: nil)
+            _storageType = State(initialValue: .fridge)
         }
     }
 
@@ -78,6 +81,13 @@ struct FoodRegisterView: View {
                 TextField("賞味期限(YYYY/MM/DD)", text: $expireText)
                     .textFieldStyle(.roundedBorder)
                     .keyboardType(.numbersAndPunctuation)
+
+                Picker("保存場所", selection: $storageType) {
+                    ForEach(StorageType.allCases) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .pickerStyle(.segmented)
 
                 ZStack(alignment: .topLeading) {
                     if note.isEmpty {
@@ -191,7 +201,8 @@ struct FoodRegisterView: View {
             "expireDate": Timestamp(date: date),
             "createdAt": Timestamp(date: Date()),
             "updatedAt": Timestamp(date: Date()),
-            "note": note
+            "note": note,
+            "storageType": storageType.rawValue
         ]
         if let image = selectedImage, let imageData = image.jpegData(compressionQuality: 0.8) {
             data["imageUrl"] = imageData.base64EncodedString()
@@ -201,12 +212,13 @@ struct FoodRegisterView: View {
                 showSaveErrorAlert = true
                 return
             }
-            let newFood = Food(id: ref.documentID, name: foodName, imageUrl: data["imageUrl"] as? String ?? "", expireDate: date, note: note.isEmpty ? nil : note)
+            let newFood = Food(id: ref.documentID, name: foodName, imageUrl: data["imageUrl"] as? String ?? "", expireDate: date, note: note.isEmpty ? nil : note, storageType: storageType)
             NotificationManager.shared.scheduleNotification(for: newFood)
             foodName = ""
             expireText = ""
             selectedImage = nil
             note = ""
+            storageType = .fridge
             showSavedAlert = true
         }
     }

--- a/Sources/FoodExpire/Models/Food.swift
+++ b/Sources/FoodExpire/Models/Food.swift
@@ -7,5 +7,6 @@ struct Food: Identifiable, Codable {
     var imageUrl: String
     var expireDate: Date
     var note: String?
+    var storageType: StorageType = .fridge
 }
 

--- a/Sources/FoodExpire/Models/StorageType.swift
+++ b/Sources/FoodExpire/Models/StorageType.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum StorageType: String, CaseIterable, Codable, Identifiable {
+    case fridge = "冷蔵"
+    case freezer = "冷凍"
+    case room = "常温"
+
+    var id: String { rawValue }
+}

--- a/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/FoodDetailViewModel.swift
@@ -15,7 +15,8 @@ class FoodDetailViewModel: ObservableObject {
             "name": food.name,
             "expireDate": Timestamp(date: food.expireDate),
             "updatedAt": Timestamp(date: Date()),
-            "note": food.note ?? ""
+            "note": food.note ?? "",
+            "storageType": food.storageType.rawValue
         ]
         Firestore.firestore().collection("foods").document(id).updateData(data) { error in
             if error == nil {

--- a/Sources/FoodExpire/Views/FoodCardView.swift
+++ b/Sources/FoodExpire/Views/FoodCardView.swift
@@ -30,8 +30,14 @@ struct FoodCardView: View {
             .clipShape(RoundedRectangle(cornerRadius: 8))
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(food.name)
-                    .font(.headline)
+                HStack {
+                    Text(food.name)
+                        .font(.headline)
+                    Spacer()
+                    Text(food.storageType.rawValue)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
                 Text(dateString)
                     .font(.subheadline)
                 Text("残り\(remainingDays)日")
@@ -50,6 +56,6 @@ struct FoodCardView: View {
 }
 
 #Preview {
-    FoodCardView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date().addingTimeInterval(86400*5)))
+    FoodCardView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date().addingTimeInterval(86400*5), storageType: .fridge))
 }
 

--- a/Sources/FoodExpire/Views/FoodDetailView.swift
+++ b/Sources/FoodExpire/Views/FoodDetailView.swift
@@ -37,6 +37,13 @@ struct FoodDetailView: View {
                 DatePicker("賞味期限", selection: $viewModel.food.expireDate, displayedComponents: .date)
                     .datePickerStyle(.compact)
 
+                Picker("保存場所", selection: $viewModel.food.storageType) {
+                    ForEach(StorageType.allCases) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .pickerStyle(.segmented)
+
                 ZStack(alignment: .topLeading) {
                     if (viewModel.food.note ?? "").isEmpty {
                         Text("開封済み・使い道・保管方法など自由に記入")
@@ -134,7 +141,7 @@ struct FoodDetailView: View {
             "name": viewModel.food.name,
             "createdAt": Timestamp(date: Date()),
             "note": viewModel.food.note ?? "",
-            "storageType": "",
+            "storageType": viewModel.food.storageType.rawValue,
             "isChecked": false
         ]
         Firestore.firestore().collection("shoppingList").addDocument(data: data) { error in
@@ -148,6 +155,6 @@ struct FoodDetailView: View {
 }
 
 #Preview {
-    FoodDetailView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date()))
+    FoodDetailView(food: Food(id: "1", name: "Sample", imageUrl: "", expireDate: Date(), storageType: .fridge))
         .environmentObject(UserSettings())
 }

--- a/Sources/FoodExpire/Views/FoodListView.swift
+++ b/Sources/FoodExpire/Views/FoodListView.swift
@@ -4,19 +4,35 @@ struct FoodListView: View {
     @StateObject private var viewModel = FoodListViewModel()
     @State private var showAdd = false
     @State private var showSettings = false
+    @State private var filter: StorageType?
     @EnvironmentObject private var userSettings: UserSettings
     @EnvironmentObject private var notificationManager: NotificationManager
 
+    private var displayedFoods: [Food] {
+        if let filter { return viewModel.foods.filter { $0.storageType == filter } }
+        return viewModel.foods
+    }
+
     var body: some View {
         NavigationStack {
-            List(viewModel.foods) { food in
-                NavigationLink {
-                    FoodDetailView(food: food)
-                } label: {
-                    FoodCardView(food: food)
+            VStack {
+                Picker("保存場所", selection: $filter) {
+                    Text("すべて").tag(StorageType?.none)
+                    ForEach(StorageType.allCases) { type in
+                        Text(type.rawValue).tag(Optional(type))
+                    }
                 }
+                .pickerStyle(.segmented)
+
+                List(displayedFoods) { food in
+                    NavigationLink {
+                        FoodDetailView(food: food)
+                    } label: {
+                        FoodCardView(food: food)
+                    }
+                }
+                .listStyle(.plain)
             }
-            .listStyle(.plain)
             .navigationTitle("食品一覧")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {


### PR DESCRIPTION
## Summary
- add `StorageType` enum and integrate with `Food` model
- let users choose storage type when registering and editing foods
- show storage type label on food cards
- filter food list by storage type
- include storage type when updating or adding to shopping list

## Testing
- `swift build` *(fails: unable to fetch dependencies, Info.plist not supported as resource)*

------
https://chatgpt.com/codex/tasks/task_e_685a6f189bb88327b393a1cf207687ca