### PR TITLE
Add recipe suggestion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The app supports both Japanese and English localizations.
 - Send notifications when items are about to expire.
 - Re-register previously saved foods from the detail screen.
 - Optional in-app purchase to remove banner ads.
+- Suggest simple recipe ideas based on foods nearing expiration.
 
 ## Setup
 1. Open `Package.swift` with Xcode 15 or later.

--- a/Sources/FoodExpire/ContentView.swift
+++ b/Sources/FoodExpire/ContentView.swift
@@ -9,6 +9,8 @@ struct ContentView: View {
                 .tabItem { Label("食品", systemImage: "list.bullet") }
             NavigationStack { ShoppingListView() }
                 .tabItem { Label("買い物", systemImage: "cart") }
+            NavigationStack { RecipeSuggestionView() }
+                .tabItem { Label("レシピ", systemImage: "lightbulb") }
         }
         .sheet(item: $notificationManager.selectedFood) { food in
             NavigationStack {

--- a/Sources/FoodExpire/ViewModels/RecipeSuggestionViewModel.swift
+++ b/Sources/FoodExpire/ViewModels/RecipeSuggestionViewModel.swift
@@ -1,0 +1,70 @@
+import Foundation
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+@MainActor
+class RecipeSuggestionViewModel: ObservableObject {
+    @Published var foods: [Food] = []
+    @Published var suggestedFoods: [Food] = []
+    @Published var recipeTitle: String = ""
+    @Published var fetchError = false
+
+    private let templates2 = [
+        "%@と%@の炒め物",
+        "%@と%@のサラダ",
+        "%@と%@の煮込み",
+        "%@と%@のバター炒め",
+        "%@と%@の和え物"
+    ]
+
+    private let templates3 = [
+        "%@・%@・%@のミックス炒め",
+        "%@と%@と%@のスープ",
+        "%@・%@・%@の簡単煮"
+    ]
+
+    func fetchFoods() {
+        Firestore.firestore()
+            .collection("foods")
+            .order(by: "expireDate")
+            .limit(to: 10)
+            .getDocuments { [weak self] snapshot, error in
+                guard let self = self else { return }
+                if error != nil {
+                    self.fetchError = true
+                    return
+                }
+                self.foods = snapshot?.documents.compactMap { try? $0.data(as: Food.self) } ?? []
+                self.generateRecipe()
+            }
+    }
+
+    func generateRecipe() {
+        guard foods.count >= 2 else {
+            suggestedFoods = []
+            recipeTitle = ""
+            return
+        }
+        let shuffled = foods.shuffled()
+        let useCount = min(shuffled.count >= 3 ? Int.random(in: 2...3) : 2, shuffled.count)
+        suggestedFoods = Array(shuffled.prefix(useCount))
+
+        if useCount == 2 {
+            if let template = templates2.randomElement() {
+                recipeTitle = String(format: template, suggestedFoods[0].name, suggestedFoods[1].name)
+            }
+        } else {
+            if let template = templates3.randomElement() {
+                recipeTitle = String(format: template, suggestedFoods[0].name, suggestedFoods[1].name, suggestedFoods[2].name)
+            }
+        }
+    }
+
+    func useFoods() {
+        for food in suggestedFoods {
+            guard let id = food.id else { continue }
+            Firestore.firestore().collection("foods").document(id).delete()
+        }
+        fetchFoods()
+    }
+}

--- a/Sources/FoodExpire/Views/RecipeSuggestionView.swift
+++ b/Sources/FoodExpire/Views/RecipeSuggestionView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct RecipeSuggestionView: View {
+    @StateObject private var viewModel = RecipeSuggestionViewModel()
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if viewModel.suggestedFoods.isEmpty {
+                Text("食品が不足しています")
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(viewModel.recipeTitle)
+                    .font(.title2)
+                    .bold()
+                List(viewModel.suggestedFoods) { food in
+                    HStack {
+                        Text(food.name)
+                        Spacer()
+                        Text(DateFormatter.expireFormatter.string(from: food.expireDate))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .listStyle(.plain)
+                Button("使う") {
+                    viewModel.useFoods()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            Button("別の提案を見る") {
+                viewModel.generateRecipe()
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
+        .navigationTitle("レシピ提案")
+        .onAppear { viewModel.fetchFoods() }
+        .alert("データの取得に失敗しました", isPresented: $viewModel.fetchError) {}
+    }
+}
+
+#Preview {
+    NavigationStack { RecipeSuggestionView() }
+}


### PR DESCRIPTION
## Summary
- generate simple recipe ideas from expiring foods
- allow using suggested foods and deleting them from Firestore
- display recipe suggestions in a new tab
- document the new feature in README

## Testing
- `swift build` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a708c9f5083278e1f5e52eb75aeb1